### PR TITLE
Update SettingActivity.java

### DIFF
--- a/app/src/main/java/com/dynamsoft/demo/dynamsoftbarcodereaderdemo/SettingActivity.java
+++ b/app/src/main/java/com/dynamsoft/demo/dynamsoftbarcodereaderdemo/SettingActivity.java
@@ -111,10 +111,7 @@ public class SettingActivity extends AppCompatActivity implements CompoundButton
 		if ("1".equals(mCache.getAsString("dotcode"))) {
 			mDotCode.setChecked(true);
 		}
-		if (mDotCode.isChecked()) {
-			nState++;
-			enabledCheckBox = mDotCode;
-		}
+		
 		updateFormatCheckboxsState();
 
 	}


### PR DESCRIPTION
Build failing due to extra code in SettingActivity.java

Lines 114-117 are already included in the method updateFormatCheckboxsState() (line 173-176) and therefore shouldn't be in  onCreate().